### PR TITLE
Improve PJe login service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Janus Web - Prova de Conceito de Login no PJe
+
+Este repositório contém um backend em Spring Boot destinado a automatizar o login no sistema PJe (Primeiro Grau) mantendo a sessão ativa para utilizações posteriores.
+
+## Como executar o backend
+
+```bash
+cd backend
+./mvnw spring-boot:run
+```
+
+O servidor iniciará na porta `8081`.
+
+## Fluxo de autenticação
+
+1. **Iniciar sessão**
+   - `GET /api/pje/iniciar-login?sessionId=UNICO`
+   - Abre a página de login do PJe e retorna o `viewState` que deve ser enviado nos próximos passos.
+
+2. **Enviar credenciais**
+   - `POST /api/pje/autenticar?sessionId=UNICO`
+   - Body: `{ "login": "cpf", "senha": "senha", "viewState": "..." }`
+   - Retorno: `{ "redirectUrl": "..." }` se as credenciais estiverem corretas. Caso haja erro, é retornado `{ "erro": "..." }`.
+
+3. **Verificar necessidade de 2FA**
+   - Caso o `redirectUrl` recebido no passo anterior aponte para o Keycloak do PJe, é necessário capturar os dados do formulário de autenticação:
+   - `GET /api/pje/capturar-keycloak?sessionId=UNICO&redirectUrl=URL`
+   - Retorno: `{ "action": "...", "execution": "..." }`.
+
+4. **Enviar código recebido por e-mail**
+   - `POST /api/pje/enviar-otp?sessionId=UNICO`
+   - Body: `{ "action": "...", "execution": "...", "otp": "123456" }`
+   - Retorno `{ "sucesso": true }` em caso de login concluído.
+
+Após a autenticação bem-sucedida, a sessão (cookies) permanece armazenada em memória, permitindo que robôs ou outras rotinas reutilizem a mesma sessão enquanto o processo estiver ativo.
+
+Este fluxo deve ser acionado pelo frontend solicitando as informações de login ao usuário, verificando se o 2FA foi solicitado e, caso necessário, exibindo um campo para o código recebido por e-mail.

--- a/backend/src/main/java/br/janus/loginpje/controller/PjeLoginController.java
+++ b/backend/src/main/java/br/janus/loginpje/controller/PjeLoginController.java
@@ -1,42 +1,87 @@
 package br.janus.loginpje.controller;
 
-import br.janus.loginpje.dto.CodigoDTO;
-import br.janus.loginpje.dto.LoginRequestDTO;
-import br.janus.loginpje.dto.LoginResponseDTO;
 import br.janus.loginpje.service.PjeLoginService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/pje")
 @CrossOrigin(origins = "*")
 public class PjeLoginController {
 
-    private final PjeLoginService loginService;
+    private final PjeLoginService service;
 
-    public PjeLoginController(PjeLoginService loginService) {
-        this.loginService = loginService;
+    public PjeLoginController(PjeLoginService service) {
+        this.service = service;
     }
 
+    /** Inicia a sessão de login e devolve o ViewState. */
     @GetMapping("/iniciar-login")
-    public ResponseEntity<String> iniciarLogin() {
-        loginService.iniciarSessao();
-        return ResponseEntity.ok("Sessão iniciada.");
-    }
-
-    @PostMapping("/autenticar")
-    public ResponseEntity<LoginResponseDTO> autenticar(@RequestBody LoginRequestDTO dto) {
-        boolean requerCodigo = loginService.enviarCredenciais(dto.login, dto.senha);
-        return ResponseEntity.ok(new LoginResponseDTO(requerCodigo));
-    }
-
-    @PostMapping("/validar-codigo")
-    public ResponseEntity<String> validarCodigo(@RequestBody CodigoDTO dto) {
-        boolean sucesso = loginService.validarCodigo(dto.codigo);
-        if (sucesso) {
-            return ResponseEntity.ok("Login finalizado");
-        } else {
-            return ResponseEntity.status(401).body("Código inválido");
+    public ResponseEntity<?> iniciarLogin(@RequestParam String sessionId) {
+        try {
+            String viewState = service.iniciarSessao(sessionId);
+            return ResponseEntity.ok(Map.of("viewState", viewState));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("erro", e.getMessage()));
         }
+    }
+
+    /** Envia login e senha. Retorna redirectUrl se sucesso ou erro. */
+    @PostMapping("/autenticar")
+    public ResponseEntity<?> autenticar(@RequestParam String sessionId, @RequestBody Map<String, String> body) {
+        try {
+            String login = body.get("login");
+            String senha = body.get("senha");
+            String viewState = body.get("viewState");
+            if (login == null || senha == null || viewState == null) {
+                return ResponseEntity.badRequest().body(Map.of("erro", "Parâmetros obrigatórios."));
+            }
+            Map<String, String> result = service.autenticar(sessionId, login, senha, viewState);
+            if (!result.containsKey("redirectUrl")) {
+                String msg = result.getOrDefault("erro", "Falha na autenticação.");
+                return ResponseEntity.status(401).body(Map.of("erro", msg));
+            }
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("erro", e.getMessage()));
+        }
+    }
+
+    /** Coleta action e execution do Keycloak para 2FA. */
+    @GetMapping("/capturar-keycloak")
+    public ResponseEntity<?> capturarKeycloak(@RequestParam String sessionId, @RequestParam String redirectUrl) {
+        try {
+            Map<String, String> result = service.capturarKeycloak(redirectUrl, sessionId);
+            return ResponseEntity.ok(result);
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("erro", e.getMessage()));
+        }
+    }
+
+    /** Envia o código de autenticação 2FA. */
+    @PostMapping("/enviar-otp")
+    public ResponseEntity<?> enviarOtp(@RequestParam String sessionId, @RequestBody Map<String, String> body) {
+        try {
+            String action = body.get("action");
+            String execution = body.get("execution");
+            String otp = body.get("otp");
+            if (action == null || execution == null || otp == null) {
+                return ResponseEntity.badRequest().body(Map.of("erro", "Dados incompletos."));
+            }
+            boolean ok = service.enviarCodigoOTP(sessionId, action, execution, otp);
+            if (ok) {
+                return ResponseEntity.ok(Map.of("sucesso", true));
+            }
+            return ResponseEntity.status(401).body(Map.of("erro", "OTP inválido."));
+        } catch (Exception e) {
+            return ResponseEntity.status(500).body(Map.of("erro", e.getMessage()));
+        }
+    }
+
+    @GetMapping("/health")
+    public ResponseEntity<?> health() {
+        return ResponseEntity.ok(Map.of("status", "ok"));
     }
 }

--- a/backend/src/main/java/br/janus/loginpje/service/SessionCookieJar.java
+++ b/backend/src/main/java/br/janus/loginpje/service/SessionCookieJar.java
@@ -1,0 +1,31 @@
+package br.janus.loginpje.service;
+
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
+import okhttp3.HttpUrl;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * CookieJar isolado por host para manter a sessão do PJe.
+ */
+public class SessionCookieJar implements CookieJar {
+
+    private final Map<String, List<Cookie>> store = new ConcurrentHashMap<>();
+
+    @Override
+    public synchronized void saveFromResponse(HttpUrl url, List<Cookie> cookies) {
+        store.put(url.host(), new ArrayList<>(cookies));
+    }
+
+    @Override
+    public synchronized List<Cookie> loadForRequest(HttpUrl url) {
+        List<Cookie> cookies = store.get(url.host());
+        return cookies != null ? new ArrayList<>(cookies) : Collections.emptyList();
+    }
+
+    public synchronized void clear() {
+        store.clear();
+    }
+}


### PR DESCRIPTION
## Summary
- add documentation on how to run the backend and login flow
- manage session cookies during the PJe login flow
- expose endpoints with sessionId and 2FA support

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6886d34e03f48324ab7b87eefe0c6ce4