### PR TITLE
Improve PJe login session handling

### DIFF
--- a/backend/src/main/java/br/janus/loginpje/service/PjeSession.java
+++ b/backend/src/main/java/br/janus/loginpje/service/PjeSession.java
@@ -1,0 +1,22 @@
+package br.janus.loginpje.service;
+
+/**
+ * Armazena o estado de uma sessão de login no PJe.
+ * Mantém cookies e o último ViewState conhecido.
+ */
+public class PjeSession {
+    private final SessionCookieJar cookieJar = new SessionCookieJar();
+    private String viewState;
+
+    public SessionCookieJar getCookieJar() {
+        return cookieJar;
+    }
+
+    public String getViewState() {
+        return viewState;
+    }
+
+    public void setViewState(String viewState) {
+        this.viewState = viewState;
+    }
+}


### PR DESCRIPTION
## Summary
- store cookies and viewState together in `PjeSession`
- reuse stored viewState when sending credentials

## Testing
- `./mvnw test` *(fails: Could not resolve dependencies)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_688a766983288324aeef2dcb324c70d0